### PR TITLE
Implement CLI entrypoint and transcript chunking

### DIFF
--- a/src/voice_transcriber/chunk.py
+++ b/src/voice_transcriber/chunk.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def chunk_transcript(
+    transcript_path: Path, output_dir: Path, max_chars: int = 1000
+) -> list[Path]:
+    """Split a transcript JSON file into smaller text chunks.
+
+    Args:
+        transcript_path: Path to the transcription JSON file.
+        output_dir: Directory where chunk files will be saved.
+        max_chars: Maximum number of characters per chunk.
+
+    Returns:
+        A list of paths to the chunk files created.
+    """
+    if not transcript_path.exists():
+        raise FileNotFoundError(f"Transcript file not found: {transcript_path}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    with open(transcript_path, encoding="utf-8") as f:
+        data = json.load(f)
+    text = data.get("text", "")
+
+    chunks = [text[i : i + max_chars] for i in range(0, len(text), max_chars)]
+    chunk_paths: list[Path] = []
+    for idx, chunk in enumerate(chunks, start=1):
+        chunk_file = output_dir / f"{transcript_path.stem}_chunk{idx}.txt"
+        with open(chunk_file, "w", encoding="utf-8") as f:
+            f.write(chunk)
+        chunk_paths.append(chunk_file)
+
+    return chunk_paths

--- a/src/voice_transcriber/main.py
+++ b/src/voice_transcriber/main.py
@@ -1,2 +1,19 @@
-def main():
-    print("Hello, World!")
+from __future__ import annotations
+
+from pathlib import Path
+
+from voice_transcriber.chunk import chunk_transcript
+from voice_transcriber.transcribe import transcribe_audio
+
+
+def main() -> None:
+    """Transcribe an audio file and chunk the resulting transcript."""
+    audio_file = Path("audio/memo1.m4a")
+    output_dir = Path("output")
+
+    transcript_path = transcribe_audio(audio_file, output_dir)
+    chunk_transcript(transcript_path, output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/voice_transcriber/transcribe.py
+++ b/src/voice_transcriber/transcribe.py
@@ -2,22 +2,23 @@ import json
 from pathlib import Path
 from typing import Any
 
-import whisper
+import whisper  # type: ignore
 
 
-def transcribe_audio(audio_path: Path,
-                      output_dir: Path, model_name: str = "base") -> Path:
+def transcribe_audio(
+    audio_path: Path, output_dir: Path, model_name: str = "base"
+) -> Path:
     """
     Transcribe an audio file using OpenAI Whisper and save the output as JSON.
-    
+
     Args:
         audio_path: Path to the audio file to transcribe
         output_dir: Directory where the output JSON file will be saved
         model_name: Whisper model to use (default: "base")
-        
+
     Returns:
         Path to the saved JSON file
-        
+
     Raises:
         FileNotFoundError: If the audio file doesn't exist
         ValueError: If the model name is invalid
@@ -25,19 +26,19 @@ def transcribe_audio(audio_path: Path,
     # Validate input
     if not audio_path.exists():
         raise FileNotFoundError(f"Audio file not found: {audio_path}")
-    
+
     # Create output directory if it doesn't exist
     output_dir.mkdir(parents=True, exist_ok=True)
-    
+
     # Load the Whisper model
     try:
         model = whisper.load_model(model_name)
     except Exception as e:
         raise ValueError(f"Failed to load model '{model_name}': {e}") from e
-    
+
     # Transcribe the audio
     result = model.transcribe(str(audio_path))
-    
+
     # Prepare the output data
     output_data: dict[str, Any] = {
         "audio_file": str(audio_path),
@@ -45,15 +46,15 @@ def transcribe_audio(audio_path: Path,
         "text": result["text"],
         "language": result.get("language", "unknown"),
         "segments": result.get("segments", []),
-        "duration": result.get("duration", 0.0)
+        "duration": result.get("duration", 0.0),
     }
-    
+
     # Create output file path
     audio_name = audio_path.stem
     output_file = output_dir / f"{audio_name}.json"
-    
+
     # Save the transcription as JSON
-    with open(output_file, 'w', encoding='utf-8') as f:
+    with open(output_file, "w", encoding="utf-8") as f:
         json.dump(output_data, f, indent=2, ensure_ascii=False)
-    
-    return output_file 
+
+    return output_file


### PR DESCRIPTION
## Summary
- add `chunk_transcript` helper to split transcription text into smaller files
- create CLI in `main.py` to transcribe and chunk audio
- update type hints and formatting in `transcribe.py`

## Testing
- `ruff check .`
- `ruff format --check .`
- `mypy src/voice_transcriber`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851ef15b1088328bdf76ed9ff3e341b